### PR TITLE
Accept empty "style" hash

### DIFF
--- a/lib/paperclip-dimension.rb
+++ b/lib/paperclip-dimension.rb
@@ -34,7 +34,8 @@ module Paperclip
     def save_dimensions_for(name)
       opts = self.class.attachment_definitions[name]
 
-      styles = opts[:styles].keys + [:original]
+      styles = [:original]
+      styles += opts[:styles].keys if opts[:styles]
       dimension_hash = {}
       styles.each do |style|
         attachment = self.send name

--- a/spec/paperclip-dimension_spec.rb
+++ b/spec/paperclip-dimension_spec.rb
@@ -4,7 +4,8 @@ describe Paperclip::Dimension do
   before(:each) do
     @p = Post.create!({
      :image =>File.open(File.dirname(__FILE__) + '/ruby.png'),
-     :another_image => File.open(File.dirname(__FILE__) + '/ruby.png')
+     :another_image => File.open(File.dirname(__FILE__) + '/ruby.png'),
+     :image_no_styles => File.open(File.dirname(__FILE__) + '/ruby.png')
     })
     @p.reload
   end
@@ -12,6 +13,13 @@ describe Paperclip::Dimension do
   it "should save dimensions" do
     @p.image_dimensions.should_not be_nil
     @p.another_image_dimensions.should_not be_nil
+    @p.image_no_styles_dimensions.should_not be_nil
+  end
+
+  it "should accept empty styles hash" do
+    @p.image_no_styles_dimension.should  == [995, 996]
+    @p.image_no_styles_dimension(:original).should == [995, 996]
+    @p.image_no_styles_dimension(:large).should be_nil
   end
 
   it "should retreive dimensions correctly" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define do
   create_table :posts do |t|
     t.attachment :image
     t.attachment :another_image
+    t.attachment :image_no_styles
   end
 end
 
@@ -54,6 +55,8 @@ class Post < ActiveRecord::Base
     :medium   =>    ['150x150>',     :jpg],
     :small    =>    ['30x30>',       :jpg]
   }
+
+  has_attached_file :image_no_styles
 end
 
 


### PR DESCRIPTION
Currently paperclip-dimension forces you to have a :styles hash for and image. This allows you to just use :original by itself.

This is a cleanup of the original PR by Mawaheb
